### PR TITLE
Add accessibilityText to standard and deferredHint

### DIFF
--- a/Tutti/Hints/Models/DeferredHint.swift
+++ b/Tutti/Hints/Models/DeferredHint.swift
@@ -25,6 +25,7 @@ open class DeferredHint: StandardHint, DeferredOnboarding {
         title: String,
         text: String,
         requiredPresentationAttempts: Int,
+        accessibilityText: String? = nil,
         userId: String? = nil,
         persistence: OnboardingPersistence = UserDefaults.standard) {
         self.requiredPresentationAttempts = requiredPresentationAttempts
@@ -32,6 +33,7 @@ open class DeferredHint: StandardHint, DeferredOnboarding {
             identifier: identifier,
             title: title,
             text: text,
+            accessibilityText: accessibilityText,
             userId: userId,
             persistence: persistence)
     }

--- a/Tutti/Hints/Models/Hint.swift
+++ b/Tutti/Hints/Models/Hint.swift
@@ -20,4 +20,5 @@ public protocol Hint: Onboarding {
     
     var title: String { get }
     var text: String { get }
+    var accessibilityText: String? { get }
 }

--- a/Tutti/Hints/Models/StandardHint.swift
+++ b/Tutti/Hints/Models/StandardHint.swift
@@ -24,8 +24,10 @@ open class StandardHint: Hint {
         identifier: String,
         title: String,
         text: String,
+        accessibilityText: String? = nil,
         userId: String? = nil,
         persistence: OnboardingPersistence = UserDefaults.standard) {
+        self.accessibilityText = accessibilityText
         self.identifier = identifier
         self.title = title
         self.text = text
@@ -41,6 +43,7 @@ open class StandardHint: Hint {
     
     // MARK: - Properties
     
+    public let accessibilityText: String?
     public let identifier: String
     public let text: String
     public let title: String

--- a/Tutti/Hints/Presenters/CalloutHintPresenter.swift
+++ b/Tutti/Hints/Presenters/CalloutHintPresenter.swift
@@ -68,7 +68,7 @@ public class CalloutHintPresenter: HintPresenter, CalloutViewDelegate {
 extension CalloutHintPresenter {
     
     func createCallout(for hint: Hint) -> CalloutView {
-        let callout = CalloutView(text: hint.text, preferences: CalloutView.globalPreferences, delegate: self)
+        let callout = CalloutView(text: hint.text, accessibilityText: hint.accessibilityText, preferences: CalloutView.globalPreferences, delegate: self)
         presentedCallouts.append(callout)
         return callout
     }

--- a/Tutti/Hints/Presenters/CalloutView.swift
+++ b/Tutti/Hints/Presenters/CalloutView.swift
@@ -125,6 +125,7 @@ public extension CalloutView {
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         tap.delegate = self
         addGestureRecognizer(tap)
+        setupAccessibility()
         
         superview.addSubview(self)
         
@@ -250,6 +251,8 @@ open class CalloutView: UIView {
     fileprivate var arrowTip = CGPoint.zero
     fileprivate(set) open var preferences: Preferences
     public let text: String
+    public let accessibilityText: String?
+    
     
     // MARK: - Lazy variables -
     
@@ -278,12 +281,12 @@ open class CalloutView: UIView {
     
     // MARK: - Initializer
     
-    public init (text: String, preferences: Preferences = CalloutView.globalPreferences, delegate: CalloutViewDelegate? = nil) {
+    public init (text: String, accessibilityText: String? = nil, preferences: Preferences = CalloutView.globalPreferences, delegate: CalloutViewDelegate? = nil) {
         
         self.text = text
         self.preferences = preferences
         self.delegate = delegate
-        
+        self.accessibilityText = accessibilityText
         super.init(frame: CGRect.zero)
         
         self.backgroundColor = UIColor.clear
@@ -312,6 +315,12 @@ open class CalloutView: UIView {
     }
     
     // MARK: - Private methods -
+    
+    private func setupAccessibility() {
+        self.isAccessibilityElement = self.accessibilityText != nil
+        self.accessibilityTraits = .staticText
+        self.accessibilityLabel = self.accessibilityText
+    }
     
     fileprivate func computeFrame(arrowPosition position: ArrowPosition, refViewFrame: CGRect, superviewFrame: CGRect) -> CGRect {
         var xOrigin: CGFloat = 0

--- a/TuttiExample/ViewController+Hints.swift
+++ b/TuttiExample/ViewController+Hints.swift
@@ -12,20 +12,24 @@ import Tutti
 extension ViewController {
     
     func getHint(forUser userId: String?) -> Hint {
+        let text = "This is a standard hint. It will only be displayed once per user."
         return StandardHint(
             identifier: "hint_standard",
             title: "Standard hint",
-            text: "This is a standard hint. It will only be displayed once per user.",
+            text: text,
+            accessibilityText: text,
             userId: userId)
     }
     
     func getDeferredHint(forUser userId: String?) -> DeferredHint {
         let requiredPresentationAttempts = 5
+        let text = "This is a deferred hint. It will be displayed after \(requiredPresentationAttempts) attempts and only once per user."
         return DeferredHint(
             identifier: "hint_deferred",
             title: "Deferred hint",
-            text: "This is a deferred hint. It will be displayed after \(requiredPresentationAttempts) attempts and only once per user.",
+            text: text,
             requiredPresentationAttempts: requiredPresentationAttempts,
+            accessibilityText: "This is a hint to help the user to learn something. To dismiss me just tap on me. \(text)",
             userId: userId)
     }
     


### PR DESCRIPTION
This PR adds a accessibilityText to hints. It is defaulted to nil so apps using this will not have to change anything and they will still work as they did before. 

But if you set the accessibilityText the hint will get focus in voiceOver and it will read the text set in accessibilityText.

 