### PR TITLE
Fix issue with hint position when rotating device.

### DIFF
--- a/Sources/Tutti/UIKit/Hints/CalloutView.swift
+++ b/Sources/Tutti/UIKit/Hints/CalloutView.swift
@@ -402,9 +402,11 @@ open class CalloutView: UIView {
         guard let sview = superview
             , presentingView != nil else { return }
         
-        UIView.animate(withDuration: 0.3) {
-            self.arrange(withinSuperview: sview)
-            self.setNeedsDisplay()
+        DispatchQueue.main.async {
+            UIView.animate(withDuration: 0.3) {
+                self.arrange(withinSuperview: sview)
+                self.setNeedsDisplay()
+            }
         }
     }
     


### PR DESCRIPTION
The previous solution (#17) didn't work in the Bookbeat app but it did work in the demo project inside Tutti. The other solutions commit has been reverted. The DispatchQueue make sure to wait until the next run loop. Then the frame has the correct position.